### PR TITLE
Add type="button" to prevent form submissions

### DIFF
--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -35,7 +35,7 @@
 
                         <!-- Clear selection button icon for single entry lookups -->
                         <template if:false={isMultiEntry}>
-                            <button title="Remove selected option"
+                            <button title="Remove selected option" type="button"
                                 onclick={handleClearSelection} class={getClearSelectionButtonClass}>
                                 <lightning-icon icon-name="utility:close" size="x-small" alternative-text="Remove selected option"
                                     class="slds-button__icon"></lightning-icon>


### PR DESCRIPTION
When this LWC is added to lightning-record-edit-form, Salesforce treats
the button used for displaying values for single entry instances as a
submit button. As a result, when the selection is cleared, the form gets
submitted, which is undesirable. Adding an attribute of type="button"
fixes this.