### PR TITLE
Expose search term

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ That list contains a maximum of one elements if the lookup is a single entry loo
 | `setSearchResults(results)` | Passes a search results array back to the lookup so that they are displayed in the dropdown. |
 | `getSelection()` | Gets the current lookup selection. |
 | `getkey()` | Retrieves the value of the `customKey` attribute. |
+| `getSearchTerm()` | Gets the value of `searchTerm` attribute. |
 
 | Event  | Description | Data |
 | --- | --- | --- |

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -43,6 +43,11 @@ export default class Lookup extends LightningElement {
         return this.customKey;
     }
 
+    @api
+    getSearchTerm() {
+        return this.searchTerm;
+    }
+
 
 // INTERNAL FUNCTIONS
 


### PR DESCRIPTION
Added getter for the search term.

Example of its use.
```html
<!-- parent.html -->
<c-lookup
    onsearch={handleSearch}
    onselectionchange={handleSelectionChange}
    label={label.search}
    placeholder={label.placeholder}
    onkeydown={handleKeydown}
>
</c-lookup>
```
```javascript
/* parent.js */
handleKeydown(event) {
    if (event.code === "Enter" || event.code === "NumpadEnter") {
        let searchTerm = event.target.getSearchTerm();
        this[NavigationMixin.Navigate](
            {
                type: "standard__webPage",
                attributes: {
                    url: `/otherPage?parameter=${searchTerm}`
                }
            },
            true
        );
    }
}
```