### PR TITLE
Adding spinner to the results dropdown to indicate status of transaction

### DIFF
--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -38,21 +38,6 @@
                             oninput={handleInput}
                         />
 
-                        <!-- Spinner -->
-                        <div
-                            role="presentation"
-                            class="slds-hide slds-input__icon slds-input__icon_right slds-is-relative"
-                        >
-                            <div
-                                role="status"
-                                class="slds-spinner slds-spinner_xx-small slds-spinner_delayed"
-                            >
-                                <span class="slds-assistive-text">Loading</span>
-                                <div class="slds-spinner__dot-a"></div>
-                                <div class="slds-spinner__dot-b"></div>
-                            </div>
-                        </div>
-
                         <!-- Search icon -->
                         <lightning-icon
                             icon-name="utility:search"
@@ -87,6 +72,14 @@
                         onclick={handleComboboxClick}
                     >
                         <ul class={getListboxClass} role="presentation">
+                            <!-- Spinner to display when waiting for results of search -->
+                            <div if:true={loading}>
+                                <lightning-spinner
+                                    alternative-text="Loading"
+                                    size="small"
+                                ></lightning-spinner>
+                            </div>
+
                             <template
                                 for:each={searchResults}
                                 for:item="result"

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -15,6 +15,7 @@ export default class Lookup extends LightningElement {
     @track searchTerm = '';
     @track searchResults = [];
     @track hasFocus = false;
+    @track loading = false;
 
     cleanSearchTerm;
     blurTimeout;
@@ -24,6 +25,9 @@ export default class Lookup extends LightningElement {
 
     @api
     setSearchResults(results) {
+        // Reset the spinner
+        this.loading = false;
+
         this.searchResults = results.map(result => {
             // Clone and complete search result if icon is missing
             if (typeof result.icon === 'undefined') {
@@ -81,6 +85,9 @@ export default class Lookup extends LightningElement {
         this.searchThrottlingTimeout = setTimeout(() => {
             // Send search event if search term is long enougth
             if (this.cleanSearchTerm.length >= MINIMAL_SEARCH_TERM_LENGTH) {
+                // Display spinner until results are returned
+                this.loading = true;
+
                 const searchEvent = new CustomEvent('search', {
                     detail: {
                         searchTerm: this.cleanSearchTerm,


### PR DESCRIPTION
This pull request will show a spinner in the results drop down.
If the server takes a long time to perform the search for some reason this will indicate to the end user that the system is currently working on related values of their latest search term.

I removed the previous spinner section b/c it is always hidden and is never displayed.