### PR TITLE
Display to user that there are no results

### DIFF
--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -80,9 +80,11 @@
                                 ></lightning-spinner>
                             </div>
 
+                            <!-- Display if results are present -->
                             <template
                                 for:each={searchResults}
                                 for:item="result"
+                                if:true={isExpanded}
                             >
                                 <li
                                     key={result.id}
@@ -111,6 +113,22 @@
                                                 class="slds-listbox__option-meta slds-listbox__option-meta_entity"
                                                 >{result.subtitle}</span
                                             >
+                                        </span>
+                                    </span>
+                                </li>
+                            </template>
+                            <!-- Display that there are no results -->
+                            <template if:false={isExpanded}>
+                                <li
+                                    role="presentation"
+                                    class="slds-listbox__item"
+                                >
+                                    <span
+                                        class="slds-media slds-listbox__option_entity"
+                                        role="option"
+                                    >
+                                        <span class="slds-media__body">
+                                            No results.
                                         </span>
                                     </span>
                                 </li>

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -206,10 +206,12 @@ export default class Lookup extends LightningElement {
     get getDropdownClass() {
         let css =
             'slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ';
-        if (this.hasFocus && this.hasResults()) {
+        if (
+            this.hasFocus &&
+            this.cleanSearchTerm &&
+            this.cleanSearchTerm.length >= MINIMAL_SEARCH_TERM_LENGTH
+        ) {
             css += 'slds-is-open';
-        } else {
-            css += 'slds-combobox-lookup';
         }
         return css;
     }


### PR DESCRIPTION
Before, there was no indicator to the end user that there are no matching results to their search term (only blankness).
This will now show an option (that is not clickable) that says there are not any results present.
It will also only show when the search input is focused and they have entered at least the minimum amount of search characters required to begin a search.

You will notice that I did remove 'css += 'slds-combobox-lookup';' b/c I could not find/figure out where it was being used or what it was applying. Could not find it in the slds documentation. Let me know if you can figure out differently. 

