### PR TITLE
Hide the label element if it is omitted

### DIFF
--- a/src/main/default/lwc/lookup/__tests__/lookupRendering.test.js
+++ b/src/main/default/lwc/lookup/__tests__/lookupRendering.test.js
@@ -35,6 +35,19 @@ describe('c-lookup rendering', () => {
         expect(detailEl.textContent).toBe('Sample Lookup');
     });
 
+    it('does not render label if omitted', () => {
+        // Create element
+        const element = createElement('c-lookup', {
+            is: Lookup
+        });
+        element.label = '';
+        document.body.appendChild(element);
+
+        // Verify label doesn't exist
+        const detailEl = element.shadowRoot.querySelector('label');
+        expect(detailEl).toBe(null);
+    });
+
     it('renders single entry (no selection)', () => {
         // Create element
         const element = createElement('c-lookup', {

--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -1,6 +1,8 @@
 <template>
     <div class="slds-form-element">
-        <label if:true={label} class="slds-form-element__label" for="combobox">{label}</label>
+        <label if:true={label} class="slds-form-element__label" for="combobox"
+            >{label}</label
+        >
         <div class="slds-form-element__control">
             <div class={getContainerClass}>
                 <div

--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -1,6 +1,6 @@
 <template>
     <div class="slds-form-element">
-        <label class="slds-form-element__label" for="combobox">{label}</label>
+        <label if:true={label} class="slds-form-element__label" for="combobox">{label}</label>
         <div class="slds-form-element__control">
             <div class={getContainerClass}>
                 <div


### PR DESCRIPTION
Allows the developer more flexibility to use this component in more locations by allowing the label element to be omitted entirely, if no label is provided.