### PR TITLE
Add titles to selected items

### DIFF
--- a/src/main/default/lwc/lookup/__tests__/lookupRendering.test.js
+++ b/src/main/default/lwc/lookup/__tests__/lookupRendering.test.js
@@ -1,6 +1,21 @@
 import { createElement } from 'lwc';
 import Lookup from 'c/lookup';
 
+const SAMPLE_SELECTION_ITEMS = [
+    {
+        id: 'id1',
+        icon: 'standard:default',
+        title: 'Sample item 1',
+        subtitle: 'sub1'
+    },
+    {
+        id: 'id2',
+        icon: 'standard:default',
+        title: 'Sample item 2',
+        subtitle: 'sub2'
+    }
+];
+
 describe('c-lookup rendering', () => {
     afterEach(() => {
         // The jsdom instance is shared across test cases in a single file so reset the DOM
@@ -75,6 +90,37 @@ describe('c-lookup rendering', () => {
             'ul.slds-listbox_inline'
         );
         expect(selList.length).toBe(1);
+    });
+
+    it('renders title on selection in single-select', () => {
+        // Create element
+        const element = createElement('c-lookup', {
+            is: Lookup
+        });
+        element.isMultiEntry = false;
+        element.selection = [SAMPLE_SELECTION_ITEMS[0]];
+        document.body.appendChild(element);
+
+        const inputBox = element.shadowRoot.querySelector('input');
+        expect(inputBox.title).toBe(SAMPLE_SELECTION_ITEMS[0].title);
+    });
+
+    it('renders title on selection in multi-select', () => {
+        // Create element
+        const element = createElement('c-lookup', {
+            is: Lookup
+        });
+        element.isMultiEntry = true;
+        element.selection = SAMPLE_SELECTION_ITEMS;
+        document.body.appendChild(element);
+
+        const inputBox = element.shadowRoot.querySelector('input');
+        expect(inputBox.title).toBe('');
+
+        const selPills = element.shadowRoot.querySelectorAll('lightning-pill');
+        expect(selPills.length).toBe(2);
+        expect(selPills[0].title).toBe(SAMPLE_SELECTION_ITEMS[0].title);
+        expect(selPills[1].title).toBe(SAMPLE_SELECTION_ITEMS[1].title);
     });
 
     it('renders errors', () => {

--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -32,6 +32,7 @@
                             id="combobox"
                             placeholder={placeholder}
                             value={getInputValue}
+                            title={getInputTitle}
                             readonly={isInputReadonly}
                             onfocus={handleFocus}
                             onblur={handleBlur}
@@ -141,6 +142,7 @@
                             >
                                 <lightning-pill
                                     label={item.title}
+                                    title={item.title}
                                     onremove={handleRemoveSelectedItem}
                                     name={item.id}
                                 >

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -273,6 +273,14 @@ export default class Lookup extends LightningElement {
         return this.hasSelection() ? this.selection[0].title : this.searchTerm;
     }
 
+    get getInputTitle() {
+        if (this.isMultiEntry) {
+            return '';
+        }
+
+        return this.hasSelection() ? this.selection[0].title : '';
+    }
+
     get getListboxClass() {
         return (
             'slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid ' +


### PR DESCRIPTION
Helps improve usability when the item name may be longer than the lookup input allows for, as the user can now hover the selected item(s) to get their full names