### PR TITLE
Disabled linkify for rich text

### DIFF
--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -90,11 +90,11 @@
                                         </span>
                                         <span class="slds-media__body">
                                             <span class="slds-listbox__option-text slds-listbox__option-text_entity">
-                                                <lightning-formatted-rich-text value={result.titleFormatted} disable-linkify="true">
+                                                <lightning-formatted-rich-text value={result.titleFormatted} disable-linkify>
                                                 </lightning-formatted-rich-text>
                                             </span>
                                             <span class="slds-listbox__option-meta slds-listbox__option-meta_entity">
-                                                <lightning-formatted-rich-text value={result.subtitleFormatted} disable-linkify="true">
+                                                <lightning-formatted-rich-text value={result.subtitleFormatted} disable-linkify>
                                                 </lightning-formatted-rich-text>
                                             </span>
                                         </span>

--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -90,11 +90,11 @@
                                         </span>
                                         <span class="slds-media__body">
                                             <span class="slds-listbox__option-text slds-listbox__option-text_entity">
-                                                <lightning-formatted-rich-text value={result.titleFormatted}>
+                                                <lightning-formatted-rich-text value={result.titleFormatted} disable-linkify="true">
                                                 </lightning-formatted-rich-text>
                                             </span>
                                             <span class="slds-listbox__option-meta slds-listbox__option-meta_entity">
-                                                <lightning-formatted-rich-text value={result.subtitleFormatted}>
+                                                <lightning-formatted-rich-text value={result.subtitleFormatted} disable-linkify="true">
                                                 </lightning-formatted-rich-text>
                                             </span>
                                         </span>


### PR DESCRIPTION
The feature "search term highlight" introduced in release 1.3.0. is interfering with links and email-addresses. I used the lookup component to search for users and returned the username and email in the search result. As you can see in the following screenshot, the search term highlight is destroying the mailto: for the email: 

<img width="247" alt="lookup_richtext_issue" src="https://user-images.githubusercontent.com/16044068/78787025-fb410e00-79a9-11ea-8341-8cdd34e2553d.png">

As I can hardly image a use case where you want to follow a link displayed in the search result pill, I disabled the linkify option in the richt text.