### PR TITLE
search result case fix

### DIFF
--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -40,12 +40,12 @@ export default class Lookup extends LightningElement {
         this.searchResults = results.map((result) => {
             // Clone and complete search result if icon is missing
             if (this.searchTerm.length > 0) {
-                const regex = new RegExp(this.searchTerm, 'gi');
+                const regex = new RegExp(`(${this.searchTerm})`, 'gi');
                 result.titleFormatted = result.title
-                    ? result.title.replace(regex, '<b>' + this.searchTerm + '</b>')
+                    ? result.title.replace(regex, '<strong>$1</strong>')
                     : result.title;
                 result.subtitleFormatted = result.subtitle
-                    ? result.subtitle.replace(regex, '<b>' + this.searchTerm + '</b>')
+                    ? result.subtitle.replace(regex, '<strong>$1</strong>')
                     : result.subtitle;
             }
             if (typeof result.icon === 'undefined') {


### PR DESCRIPTION
The current version of the component has one drawback. When we enter the search term, the matching characters in the results found are changed in a way that matches the case of the search term. For instance:
![Screenshot_1](https://user-images.githubusercontent.com/32707473/79008986-35a3da00-7b67-11ea-8fd9-bc1e9c03c8a5.png) ![Screenshot_2](https://user-images.githubusercontent.com/32707473/79008993-3b99bb00-7b67-11ea-87b4-c4b48576b791.png) ![Screenshot_3](https://user-images.githubusercontent.com/32707473/79009004-3fc5d880-7b67-11ea-943c-0c0d75d57c5a.png)

So I have updated the  `lookup.js` file now it works as expected. 
![image](https://user-images.githubusercontent.com/32707473/79010051-c085d400-7b69-11ea-9b0a-c865eefbcdaf.png) ![image](https://user-images.githubusercontent.com/32707473/79010029-af3cc780-7b69-11ea-9489-7dcf5107886d.png) ![image](https://user-images.githubusercontent.com/32707473/79010087-d8f5ee80-7b69-11ea-89eb-4550db02a8a8.png)

It also seems to be more appropriate to use the `<strong>` tag, instead of `<b>`, to add additional semantic meaning and not just the styling.