### PR TITLE
Add keyboard support, and add selection ids to selectionchange event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .localdevserver
 node_modules
 coverage
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The `selectionchange` event handler can then get the current selection by callin
 
 ```js
 handleSelectionChange(event) {
+    const selectedIds = event.detail; // Same interface as lightning-input-field
     const selection = event.target.getSelection();
     // TODO: do something with the lookup selection
 }
@@ -139,7 +140,7 @@ That list contains a maximum of one elements if the lookup is a single entry loo
 | `getSelection()`            | Gets the current lookup selection as an array of `LookupSearchResult`.                                                                          |
 | `getkey()`                  | Retrieves the value of the `customKey` attribute.                                                                                               |
 
-| Event             | Description                                                                                                                                        | Data                                              |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `search`          | Event fired when a search needs to be performed on the server-side.                                                                                | `{ searchTerm: String, selectedIds: [ String ] }` |
-| `selectionchange` | Event fired when the selection of the lookup changes. This event holds no data, use the `getSelection` function to retrieve the current selection. | none                                              |
+| Event             | Description                                                                                                                                                           | Data                                              |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `search`          | Event fired when a search needs to be performed on the server-side.                                                                                                   | `{ searchTerm: String, selectedIds: [ String ] }` |
+| `selectionchange` | Event fired when the selection of the lookup changes. Selection ids are in the event details, or use `target.getSelection()` to retrieve the selected lookup objects. | `{ detail: [ String ] }`                          |

--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -35,6 +35,7 @@
                             onfocus={handleFocus}
                             onblur={handleBlur}
                             oninput={handleInput}
+                            onkeydown={handleKeyDown}
                         />
 
                         <!-- Search icon -->
@@ -73,17 +74,17 @@
                             </div>
 
                             <!-- Display if results are present -->
-                            <template for:each={searchResults} for:item="result" if:true={isExpanded}>
-                                <li key={result.id} role="presentation" class="slds-listbox__item">
+                            <template for:each={searchResultsLocalState} for:item="item" if:true={isExpanded}>
+                                <li key={item.result.id} role="presentation" class="slds-listbox__item">
                                     <span
-                                        class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta"
+                                        class={item.getClass}
                                         role="option"
                                         onclick={handleResultClick}
-                                        data-recordid={result.id}
+                                        data-recordid={item.result.id}
                                     >
                                         <span class="slds-media__figure">
                                             <lightning-icon
-                                                icon-name={result.icon}
+                                                icon-name={item.result.icon}
                                                 size="small"
                                                 alternative-text="Result item icon"
                                             ></lightning-icon>
@@ -91,14 +92,14 @@
                                         <span class="slds-media__body">
                                             <span class="slds-listbox__option-text slds-listbox__option-text_entity">
                                                 <lightning-formatted-rich-text
-                                                    value={result.titleFormatted}
+                                                    value={item.result.titleFormatted}
                                                     disable-linkify
                                                 >
                                                 </lightning-formatted-rich-text>
                                             </span>
                                             <span class="slds-listbox__option-meta slds-listbox__option-meta_entity">
                                                 <lightning-formatted-rich-text
-                                                    value={result.subtitleFormatted}
+                                                    value={item.result.subtitleFormatted}
                                                     disable-linkify
                                                 >
                                                 </lightning-formatted-rich-text>

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -162,7 +162,11 @@ export default class Lookup extends LightningElement {
         this.searchResults = [];
 
         // Notify parent components that selection has changed
-        this.dispatchEvent(new CustomEvent('selectionchange'));
+        this.dispatchSelectionChange();
+    }
+
+    dispatchSelectionChange() {
+        this.dispatchEvent(new CustomEvent('selectionchange', { detail: this.curSelection.map((sel) => sel.id) }));
     }
 
     handleComboboxClick() {
@@ -199,14 +203,14 @@ export default class Lookup extends LightningElement {
         this.curSelection = this.curSelection.filter((item) => item.id !== recordId);
         this.isDirty = true;
         // Notify parent components that selection has changed
-        this.dispatchEvent(new CustomEvent('selectionchange'));
+        this.dispatchSelectionChange();
     }
 
     handleClearSelection() {
         this.curSelection = [];
         this.isDirty = true;
         // Notify parent components that selection has changed
-        this.dispatchEvent(new CustomEvent('selectionchange'));
+        this.dispatchSelectionChange();
     }
 
     // STYLE EXPRESSIONS


### PR DESCRIPTION
Hi Philippe, thank you for this excellent library! We *finally* got to the end of our ability to customize lightning-input-field and needed to build our own lookup; thankfully your library got us most of the way there and saved a lot of work.

There are a couple changes in this PR:

First, I added `{detail: <selected ids>}` to the `selectionchange` event. This matches the signature in `lightning-input-field` lookups to make migration easier, and it also probably takes care of the vast majority of uses cases where you end up with `event.target.getSelection().map((sel) => sel.id)`.

Second is more significant. The lookup is currently missing keyboard support- it otherwise seems to do a nice job adhering to the SLDC listbox guidelines. I've done a decent amount of manual testing and the functionality seems right, in terms of being intuitive and sticking to SLDC guidelines. It also fit really well into what you've already built.

Let me know if you are open to merging these changes, and if so, if you need anything else to make them mergeable. If not, no worries, it's easy enough to maintain our own fork. Thanks again for the library! I hope we can open source our own LWC components soon.