### PR TITLE
Double Border on Single Entry

### DIFF
--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -326,7 +326,10 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     }
 
     get getContainerClass() {
-        let css = 'slds-combobox_container slds-has-inline-listbox ';
+        let css = 'slds-combobox_container '; 
+        if (this.isMultiEntry) {
+            css += 'slds-has-inline-listbox ';
+        }
         if (this._hasFocus && this.hasResults) {
             css += 'slds-has-input-focus ';
         }


### PR DESCRIPTION
For single entry inputs, there was a double border effect created by the slds-has-inline-listbox class. I have added that to the ContainerClass css only if isMultiEntry is true.