### PR TITLE
New record options should be visible when there are no search results

### DIFF
--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -340,7 +340,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     get getDropdownClass() {
         let css = 'slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ';
         const isSearchTermValid = this._cleanSearchTerm && this._cleanSearchTerm.length >= this.minSearchTermLength;
-        if (this._hasFocus && this.isSelectionAllowed() && (isSearchTermValid || this.hasResults)) {
+        if (this._hasFocus && this.isSelectionAllowed() && (isSearchTermValid || this.hasResults || this.newRecordOptions.length)) {
             css += 'slds-is-open';
         }
         return css;


### PR DESCRIPTION
@pozil thanks for a great component.

Currently, when there are no search results and no current selection, then the new record options are not displayed (because the drop-down is not opened).

Could you please review this PR?  It ensures that the drop-down list opens to display the new record options, if they exist, even when there are no search results:

![new-record-options-when-no-results](https://user-images.githubusercontent.com/534981/145956751-40f08214-2389-4cc3-9d4f-b65f2648c8b8.png)

