### PR TITLE
wire default options feature

### DIFF
--- a/src/main/default/lwc/lookup/lookup.css
+++ b/src/main/default/lwc/lookup/lookup.css
@@ -28,3 +28,6 @@
     color: rgb(194, 57, 52);
     display: block;
 }
+.error-text {
+    color: rgb(194, 57, 52);
+}

--- a/src/main/default/lwc/lookup/lookup.html
+++ b/src/main/default/lwc/lookup/lookup.html
@@ -194,5 +194,6 @@
             </template>
             <!-- Errors end -->
         </div>
+        <div if:false={isValid} class="slds-form-element__help error-text" id="error-message">{errorMessage}</div>
     </div>
 </template>

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -211,8 +211,9 @@ export default class Lookup extends NavigationMixin(LightningElement) {
 
     // INTERNAL FUNCTIONS
     getRecordsParam(recordIds = this.selectedIds) {
-        const params = [];
+        let params;
         if (this.fields && recordIds) {
+            params = [];
             const fields = this.fields;
             recordIds.reduce((records, recordId) => {
                 records.push({ recordIds: [recordId], fields });

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -52,44 +52,49 @@ export default class Lookup extends NavigationMixin(LightningElement) {
 
     // PUBLIC FUNCTIONS AND GETTERS/SETTERS
     @api
-    get fields(){
-      return this._fields?.filter((field, index) => index <= 1) ?? [this.title, this.subtitle]?.filter(value => !!value);
+    get fields() {
+        return (
+            this._fields?.filter((field, index) => index <= 1) ??
+            [this.title, this.subtitle]?.filter((value) => !!value)
+        );
     }
-    set fields(value){
-      switch(typeof(value)){
-        case 'string':
-          this._fields = value?.split(',')?.map(field => field.trim());
-          break;
-        case 'object':
-          if(Array.isArray(value)) this._fields = value?.map(field => field?.trim());
-          break;
-        default:
-          break;
-      }
+    set fields(value) {
+        switch (typeof value) {
+            case 'string':
+                this._fields = value?.split(',')?.map((field) => field.trim());
+                break;
+            case 'object':
+                if (Array.isArray(value)) this._fields = value?.map((field) => field?.trim());
+                break;
+            default:
+                break;
+        }
     }
-    @api 
-    get options(){
-      return this._searchResults ?? this._defaultSearchResults; //this.searchResultsLocalState;
+    @api
+    get options() {
+        return this._searchResults ?? this._defaultSearchResults; //this.searchResultsLocalState;
     }
-    set options(value){
-      value = Array.isArray(value) ? value : [value];
-      this.setDefaultResults(value);
+    set options(value) {
+        value = Array.isArray(value) ? value : [value];
+        this.setDefaultResults(value);
     }
     @api
     set selection(initialSelection) {
         let selection;
-        switch(typeof(initialSelection)){
-          case 'string':
-            initialSelection = initialSelection?.split?.(';');
-            const options = this._searchResults ?? this._defaultSearchResults;
-            selection = options?.length ? options?.filter(({id}) => initialSelection.includes(id)) : initialSelection;
-            break;
-          case 'object':
-            selection = Array.isArray(initialSelection) ? initialSelection : [initialSelection];
-            break;
-          default:
-            selection = initialSelection;
-            break;
+        switch (typeof initialSelection) {
+            case 'string':
+                initialSelection = initialSelection?.split?.(';');
+                const options = this._searchResults ?? this._defaultSearchResults;
+                selection = options?.length
+                    ? options?.filter(({ id }) => initialSelection.includes(id))
+                    : initialSelection;
+                break;
+            case 'object':
+                selection = Array.isArray(initialSelection) ? initialSelection : [initialSelection];
+                break;
+            default:
+                selection = initialSelection;
+                break;
         }
         this._curSelection = selection;
         this.processSelectionUpdate(false);
@@ -99,10 +104,10 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     }
 
     //public functions
-    @api reportValidity(){
+    @api reportValidity() {
         return this.required ? this.selection?.length : true;
     }
-    
+
     @api
     setSearchResults(results) {
         // Reset the spinner
@@ -110,9 +115,9 @@ export default class Lookup extends NavigationMixin(LightningElement) {
         // Clone results before modifying them to avoid Locker restriction
         let resultsLocal = JSON.parse(JSON.stringify(results));
         // Remove selected items from search results
-        const selectedIds = this._curSelection?.filter(sel => !!sel?.id)?.map((sel) => sel.id) ?? [];
-        if(selectedIds?.length){
-          resultsLocal = resultsLocal?.filter(({id}) => selectedIds?.indexOf(id) === -1);
+        const selectedIds = this.selectedIds;
+        if (selectedIds?.length) {
+            resultsLocal = resultsLocal?.filter(({ id }) => selectedIds?.indexOf(id) === -1);
         }
         // Format results
         const cleanSearchTerm = this._searchTerm.replace(REGEX_SOSL_RESERVED, '.?').replace(REGEX_EXTRA_TRAP, '\\$1');
@@ -144,7 +149,8 @@ export default class Lookup extends NavigationMixin(LightningElement) {
                 result,
                 state: {},
                 get classes() {
-                    let css = 'slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta';
+                    let css =
+                        'slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta';
                     if (result.subtitleFormatted) {
                         css += ' slds-listbox__option_has-meta';
                     }
@@ -169,45 +175,46 @@ export default class Lookup extends NavigationMixin(LightningElement) {
             this.setSearchResults(this._defaultSearchResults);
         }
     }
-    
+
     //lifecycle hooks
-    connectedCallback(){
-      if(this.wireDefaultOptions) this.recordsParam = this.getRecordsParam();
+    connectedCallback() {
+        if (this.wireDefaultOptions) this.recordsParam = this.getRecordsParam();
     }
 
     // WIRED PROPERTIES/FUNCTIONS
-    @wire(getRecords, {records: '$recordsParam', fields: '$fields'})
-    handleGetRecordsResponse(response){
-      // console.log(`%c**getRecords response => ${JSON.stringify(response)}`, 'color:purple;font-wight:bold;');
-      // const {data:{results}} = response;
-      const results = response?.data?.results;
-      const icon = this.icon;
-      const defaultOptions = results?.map(({statusCode, result}) =>{
-        // console.log(`%c**statusCode => ${statusCode}, result => ${JSON.stringify(result)}`, `color: ${statusCode === 200 ? 'green;' : 'red;'}`);
-        if(statusCode === 200 && !!result){
-          const {fields, id} = result;
-          const option = {id, icon}
-          this.fields?.map((field, index) => {
-            const apiName = field?.split('.')?.at(1);
-            const propName = index === 0 ? 'title' : 'subtitle';
-            const value = fields[apiName]?.displayValue ?? fields[apiName]?.value;
-            option[propName] = value;
-          });
-          return option;
-        }
-      }) ?? [];
-      this.options = defaultOptions;
-      this._curSelection = this.options?.filter(({id}) => this.selectedIds?.includes(id));
+    @wire(getRecords, { records: '$recordsParam', fields: '$fields' })
+    handleGetRecordsResponse(response) {
+        // console.log(`%c**getRecords response => ${JSON.stringify(response)}`, 'color:purple;font-wight:bold;');
+        // const {data:{results}} = response;
+        const results = response?.data?.results;
+        const icon = this.icon;
+        const defaultOptions =
+            results?.map(({ statusCode, result }) => {
+                // console.log(`%c**statusCode => ${statusCode}, result => ${JSON.stringify(result)}`, `color: ${statusCode === 200 ? 'green;' : 'red;'}`);
+                if (statusCode === 200 && !!result) {
+                    const { fields, id } = result;
+                    const option = { id, icon };
+                    this.fields?.map((field, index) => {
+                        const apiName = field?.split('.')?.at(1);
+                        const propName = index === 0 ? 'title' : 'subtitle';
+                        const value = fields[apiName]?.displayValue ?? fields[apiName]?.value;
+                        option[propName] = value;
+                    });
+                    return option;
+                }
+            }) ?? [];
+        this.options = defaultOptions;
+        this._curSelection = this.options?.filter(({ id }) => this.selectedIds?.includes(id));
     }
 
     // INTERNAL FUNCTIONS
-    getRecordsParam(recordIds = this.selectedIds){
-      const fields =  this.fields;
-      if(!recordIds || !fields) return;
-      return recordIds?.reduce((records, recordId) =>{
-        !!recordId ? records.push({recordIds: [recordId], fields}) : null;
-        return records;
-      }, []);
+    getRecordsParam(recordIds = this.selectedIds) {
+        const fields = this.fields;
+        if (!recordIds || !fields) return;
+        return recordIds?.reduce((records, recordId) => {
+            !!recordId ? records.push({ recordIds: [recordId], fields }) : null;
+            return records;
+        }, []);
     }
 
     updateSearchTerm(newSearchTerm) {
@@ -273,7 +280,9 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     // EVENT HANDLING
 
     handleInput(event) {
-        const {target: {value}} = event;
+        const {
+            target: { value }
+        } = event;
         // Prevent action if selection is not allowed
         if (!this.isSelectionAllowed) {
             return;
@@ -282,10 +291,10 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     }
 
     handleKeyDown(event) {
-        const {keyCode} = event;
+        const { keyCode } = event;
         let index = this._focusedResultIndex ?? -1;
-        
-        switch(keyCode){
+
+        switch (keyCode) {
             case KEY_ARROW_DOWN:
                 index++;
                 index = index >= this._searchResults?.length ? 0 : index;
@@ -294,12 +303,12 @@ export default class Lookup extends NavigationMixin(LightningElement) {
                 break;
             case KEY_ARROW_UP:
                 index--;
-                index = index < 0 ? this._searchResults?.length -1 ?? -1 : index;
+                index = index < 0 ? this._searchResults?.length - 1 ?? -1 : index;
                 this._focusedResultIndex = index;
                 event.preventDefault();
                 break;
             case KEY_ENTER:
-                if(this._hasFocus && index >= 0){
+                if (this._hasFocus && index >= 0) {
                     const selectedId = this._searchResults?.at(index)?.id;
                     this.template.querySelector(`[data-recordid="${selectedId}"]`)?.click();
                     this._focusedResultIndex = index;
@@ -309,14 +318,13 @@ export default class Lookup extends NavigationMixin(LightningElement) {
             default:
                 break;
         }
-
     }
 
     handleResultClick(event) {
         const recordId = event.currentTarget.dataset.recordid;
         // Save selection
-        const selectedItem = this._searchResults.find(({id}) => id === recordId);
-        if(!selectedItem) return;
+        const selectedItem = this._searchResults.find(({ id }) => id === recordId);
+        if (!selectedItem) return;
         const curSelection = !!this._curSelection ? [...this._curSelection] : [];
         this._curSelection = [...curSelection, selectedItem];
         // Process selection update
@@ -357,7 +365,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
             return;
         }
         const recordId = event.currentTarget.name;
-        this._curSelection = this._curSelection?.filter(({id}) => id !== recordId);
+        this._curSelection = this._curSelection?.filter(({ id }) => id !== recordId);
         // Process selection update
         this.processSelectionUpdate(true);
     }
@@ -395,27 +403,24 @@ export default class Lookup extends NavigationMixin(LightningElement) {
         return this._searchResults?.length > 0;
     }
 
-    get hasSelection(){
-      return this.selection?.length > 0;
+    get hasSelection() {
+        return this.selection?.length > 0;
     }
 
-    get selectedIds(){
-      return this._curSelection?.map(value => {
-        switch(typeof(value)){
-          case 'string':
-            return value;
-          default:
-            return value?.id;
-        }
-      });
+    get selectedIds() {
+        return this._curSelection?.map((value) => {
+            switch (typeof value) {
+                case 'string':
+                    return value;
+                default:
+                    return value?.id;
+            }
+        });
     }
-    
+
     get isSelectionAllowed() {
-      if (this.isMultiEntry) {
-          return true;
-      }
-      return !this.hasSelection;
-  }
+        return this.isMultiEntry ? true : !this.hasSelection;
+    }
 
     get getFormElementClass() {
         return this.variant === VARIANT_LABEL_INLINE
@@ -448,11 +453,11 @@ export default class Lookup extends NavigationMixin(LightningElement) {
 
     get getInputClass() {
         let css = 'slds-input slds-combobox__input has-custom-height';
-        switch(true){
-            case (this._hasFocus && this.hasResults):
+        switch (true) {
+            case this._hasFocus && this.hasResults:
                 css += ' slds-has-focus';
                 break;
-            case (this.errors?.length > 0 || (this._isDirty && this.required && !this.hasSelection)):
+            case this.errors?.length > 0 || (this._isDirty && this.required && !this.hasSelection):
                 css += ' has-custom-error';
                 break;
             case !this.isMultiEntry:
@@ -466,13 +471,13 @@ export default class Lookup extends NavigationMixin(LightningElement) {
 
     get getComboboxClass() {
         let css = 'slds-combobox__form-element slds-input-has-icon';
-        this.hasSelection ? css += ' slds-input-has-icon_left-right' : css += ' slds-input-has-icon_right';
+        this.hasSelection ? (css += ' slds-input-has-icon_left-right') : (css += ' slds-input-has-icon_right');
         return css;
     }
 
     get getSearchIconClass() {
         let css = 'slds-input__icon slds-input__icon_right';
-        !this.isMultiEntry ? css += ' slds-hide' : null;
+        !this.isMultiEntry ? (css += ' slds-hide') : null;
         return css;
     }
 
@@ -503,11 +508,14 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     }
 
     get getListboxClass() {
-        return `slds-dropdown${this.scrollAfterNItems ? ` slds-dropdown_length-with-icon-${this.scrollAfterNItems} slds-dropdown_fluid`: ' slds-dropdown_fluid'}`;
+        return `slds-dropdown${
+            this.scrollAfterNItems
+                ? ` slds-dropdown_length-with-icon-${this.scrollAfterNItems} slds-dropdown_fluid`
+                : ' slds-dropdown_fluid'
+        }`;
     }
 
     get isInputReadonly() {
         return this.isMultiEntry ? false : this.hasSelection;
     }
-
 }

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -238,7 +238,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
                     detail: {
                         searchTerm: this._cleanSearchTerm,
                         rawSearchTerm: newSearchTerm,
-                        selectedIds: this.selectedIds;
+                        selectedIds: this.selectedIds
                     }
                 });
                 this.dispatchEvent(searchEvent);

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -105,19 +105,29 @@ export default class Lookup extends NavigationMixin(LightningElement) {
 
     //public functions
     @api reportValidity() {
-        return this.required ? this.selection?.length : true;
+        const isValid = this.required ? this.selectedIds?.length : true;
+        const formElement = this.template.querySelector('.slds-form-element');
+        // isValid ? formElement?.classList?.remove('slds-has-error') : formElement?.classList?.add('slds-has-error');
+        if (isValid) {
+            formElement?.classList?.remove('slds-has-error');
+        }
+        if (!isValid) {
+            formElement?.classList?.add('slds-has-error');
+        }
+        return isValid;
     }
 
     @api
     setSearchResults(results) {
+        if (!results) return;
         // Reset the spinner
         this.loading = false;
         // Clone results before modifying them to avoid Locker restriction
         let resultsLocal = JSON.parse(JSON.stringify(results));
         // Remove selected items from search results
-        const selectedIds = this.selectedIds;
-        if (selectedIds?.length) {
-            resultsLocal = resultsLocal?.filter(({ id }) => selectedIds?.indexOf(id) === -1);
+        if (resultsLocal?.length) {
+            const selectedIds = this.selectedIds ?? [];
+            resultsLocal = resultsLocal?.filter((item) => selectedIds?.indexOf(item?.id) === -1);
         }
         // Format results
         const cleanSearchTerm = this._searchTerm.replace(REGEX_SOSL_RESERVED, '.?').replace(REGEX_EXTRA_TRAP, '\\$1');
@@ -343,6 +353,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
         this._curSelection = [...curSelection, selectedItem];
         // Process selection update
         this.processSelectionUpdate(true);
+        this.reportValidity();
     }
 
     handleComboboxMouseDown(event) {
@@ -372,6 +383,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
             return;
         }
         this._hasFocus = false;
+        this.reportValidity();
     }
 
     handleRemoveSelectedItem(event) {
@@ -382,6 +394,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
         this._curSelection = this._curSelection?.filter(({ id }) => id !== recordId);
         // Process selection update
         this.processSelectionUpdate(true);
+        this.reportValidity();
     }
 
     handleClearSelection() {

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -80,11 +80,11 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     }
     @api
     set selection(initialSelection) {
-        let selection;
+        let options, selection;
         switch (typeof initialSelection) {
             case 'string':
                 initialSelection = initialSelection?.split?.(';');
-                const options = this._searchResults ?? this._defaultSearchResults;
+                options = this._searchResults ?? this._defaultSearchResults;
                 selection = options?.length
                     ? options?.filter(({ id }) => initialSelection.includes(id))
                     : initialSelection;
@@ -189,33 +189,46 @@ export default class Lookup extends NavigationMixin(LightningElement) {
         const results = response?.data?.results;
         const icon = this.icon;
         const defaultOptions =
-            results?.map(({ statusCode, result }) => {
-                // console.log(`%c**statusCode => ${statusCode}, result => ${JSON.stringify(result)}`, `color: ${statusCode === 200 ? 'green;' : 'red;'}`);
-                if (statusCode === 200 && !!result) {
+            results?.reduce((options, item) => {
+                const { result, statusCode } = item;
+                if (statusCode === 200 && result) {
                     const { fields, id } = result;
                     const option = { id, icon };
-                    this.fields?.map((field, index) => {
+                    this.fields?.forEach((field, index) => {
                         const apiName = field?.split('.')?.at(1);
                         const propName = index === 0 ? 'title' : 'subtitle';
                         const value = fields[apiName]?.displayValue ?? fields[apiName]?.value;
                         option[propName] = value;
                     });
-                    return option;
+                    options.push(option);
                 }
-            }) ?? [];
-        this.options = defaultOptions;
+                return options;
+            }, []) ?? [];
+        this._options = defaultOptions;
+        this.setDefaultResults(defaultOptions);
         this._curSelection = this.options?.filter(({ id }) => this.selectedIds?.includes(id));
     }
 
     // INTERNAL FUNCTIONS
     getRecordsParam(recordIds = this.selectedIds) {
-        const fields = this.fields;
-        if (!recordIds || !fields) return;
-        return recordIds?.reduce((records, recordId) => {
-            !!recordId ? records.push({ recordIds: [recordId], fields }) : null;
-            return records;
-        }, []);
+        const params = [];
+        if (this.fields && recordIds) {
+            const fields = this.fields;
+            recordIds.reduce((records, recordId) => {
+                records.push({ recordIds: [recordId], fields });
+                return records;
+            }, params);
+        }
+        return params;
     }
+    // getRecordsParam(recordIds = this.selectedIds) {
+    //     const fields = this.fields;
+    //     if (!recordIds || !fields) return;
+    //     return recordIds?.reduce((records, recordId) => {
+    //         recordId ? records.push({ recordIds: [recordId], fields }) : null;
+    //         return records;
+    //     }, []);
+    // }
 
     updateSearchTerm(newSearchTerm) {
         this._searchTerm = newSearchTerm;
@@ -325,7 +338,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
         // Save selection
         const selectedItem = this._searchResults.find(({ id }) => id === recordId);
         if (!selectedItem) return;
-        const curSelection = !!this._curSelection ? [...this._curSelection] : [];
+        const curSelection = this._curSelection ? [...this._curSelection] : [];
         this._curSelection = [...curSelection, selectedItem];
         // Process selection update
         this.processSelectionUpdate(true);
@@ -346,7 +359,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
 
     handleFocus() {
         // Prevent action if selection is not allowed
-        if (!!this.isSelectionAllowed) {
+        if (this.isSelectionAllowed) {
             this._hasFocus = true;
             this._focusedResultIndex = null;
         }
@@ -471,13 +484,13 @@ export default class Lookup extends NavigationMixin(LightningElement) {
 
     get getComboboxClass() {
         let css = 'slds-combobox__form-element slds-input-has-icon';
-        this.hasSelection ? (css += ' slds-input-has-icon_left-right') : (css += ' slds-input-has-icon_right');
+        css += `${this.hasSelection ? ' slds-input-has-icon_left-right' : ' slds-input-has-icon_right'}`;
         return css;
     }
 
     get getSearchIconClass() {
         let css = 'slds-input__icon slds-input__icon_right';
-        !this.isMultiEntry ? (css += ' slds-hide') : null;
+        if (!this.isMultiEntry) css += ' slds-hide';
         return css;
     }
 

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -127,7 +127,7 @@ export default class Lookup extends NavigationMixin(LightningElement) {
             }
             // Add icon if missing
             if (typeof result.icon === 'undefined') {
-                result.icon = 'standard:default';
+                result.icon = this.icon ?? 'standard:default';
             }
             return result;
         });
@@ -423,22 +423,22 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     }
 
     get getContainerClass() {
-        let css = 'slds-combobox_container ';
+        let css = 'slds-combobox_container';
         if (this.errors.length > 0) {
-            css += 'has-custom-error';
+            css += ' has-custom-error';
         }
         return css;
     }
 
     get getDropdownClass() {
-        let css = 'slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ';
+        let css = 'slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click';
         const isSearchTermValid = this._cleanSearchTerm && this._cleanSearchTerm.length >= this.minSearchTermLength;
         if (
             this._hasFocus &&
             this.isSelectionAllowed &&
             (isSearchTermValid || this.hasResults || this.newRecordOptions?.length)
         ) {
-            css += 'slds-is-open';
+            css += ' slds-is-open';
         }
         return css;
     }
@@ -487,7 +487,9 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     }
 
     get getSelectIconClass() {
-        return 'slds-combobox__input-entity-icon ' + (this.hasSelection ? '' : 'slds-hide');
+        let cls = 'slds-combobox__input-entity-icon';
+        !this.hasSelection ? cls += ' slds-hide';
+        return cls;
     }
 
     get getInputValue() {
@@ -499,11 +501,10 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     }
 
     get getListboxClass() {
-        return (
-            'slds-dropdown ' +
-            (this.scrollAfterNItems ? `slds-dropdown_length-with-icon-${this.scrollAfterNItems} ` : '') +
-            'slds-dropdown_fluid'
-        );
+        let cls = 'slds-dropdown';
+        this.scrollAfterNItems ? cls += ' slds-dropdown_length-with-icon-${this.scollAfterNItems}` : null;
+        cls += 'slds-dropdwon_fluid';
+        return cls;
     }
 
     get isInputReadonly() {

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -296,8 +296,8 @@ export default class Lookup extends NavigationMixin(LightningElement) {
                 if(this._hasFocus && this._focusedResultIndex >= 0) {
                     // If the user presses enter, and the box is open, and we have used arrows,
                     // treat this just like a click on the listbox item
-                    const selectedId = this._searchResults[this._focusedResultIndex].id;
-                    this.template.querySelector(`[data-recordid="${selectedId}"]`).click();
+                    const selectedId = this._searchResults?.at(this._focusedResultIndex)?.id;
+                    this.template.querySelector(`[data-recordid="${selectedId}"]`)?.click();
                 }
                 break;
             default:


### PR DESCRIPTION
added features to enable users to pass the selection property a salesforce id/string of salesforce ids delimted by a semi-colon (;) or an array of salesforce ids. if the wireDefaultOptions prop is set to true the component will invoke the getRecords wire adapter and then build the options with the response results enabling an automated selection default for salesforce records in the lookup