### PR TITLE
fix(selection): fix component crash due to selection being undefined

### DIFF
--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -46,8 +46,10 @@ export default class Lookup extends NavigationMixin(LightningElement) {
     // PUBLIC FUNCTIONS AND GETTERS/SETTERS
     @api
     set selection(initialSelection) {
-        this._curSelection = Array.isArray(initialSelection) ? initialSelection : [initialSelection];
-        this.processSelectionUpdate(false);
+        if (initialSelection && initialSelection.length > 0) {
+            this._curSelection = Array.isArray(initialSelection) ? initialSelection : [initialSelection];
+            this.processSelectionUpdate(false);
+        }
     }
 
     get selection() {


### PR DESCRIPTION
# Issue this PR fixes
Used the component in both creation and update scenarios.
In some cases (eg. When creating a record without selecting any value in the lookup) the selection was empty in the case of an update, that lead to the component crashing.