### PR TITLE
Pclookup keyDown scroll navigation focus fix

### DIFF
--- a/src/main/default/lwc/lookup/__tests__/lookupEventHandling.test.js
+++ b/src/main/default/lwc/lookup/__tests__/lookupEventHandling.test.js
@@ -100,7 +100,8 @@ describe('c-lookup event handling', () => {
         // Check selection
         expect(lookupEl.selection.length).toBe(1);
         expect(lookupEl.selection[0].id).toBe(SAMPLE_SEARCH_ITEMS[0].id);
-
+        
+        // Check if the scroll focus is functional
         const focusedElement = lookupEl.shadowRoot.querySelector(`[data-recordid="${SAMPLE_SEARCH_ITEMS[0].id}"]`);
         expect(focusedElement.scrollIntoView).toHaveBeenCalled();
     });

--- a/src/main/default/lwc/lookup/__tests__/lookupEventHandling.test.js
+++ b/src/main/default/lwc/lookup/__tests__/lookupEventHandling.test.js
@@ -100,7 +100,7 @@ describe('c-lookup event handling', () => {
         // Check selection
         expect(lookupEl.selection.length).toBe(1);
         expect(lookupEl.selection[0].id).toBe(SAMPLE_SEARCH_ITEMS[0].id);
-        
+
         // Check if the scroll focus is functional
         const focusedElement = lookupEl.shadowRoot.querySelector(`[data-recordid="${SAMPLE_SEARCH_ITEMS[0].id}"]`);
         expect(focusedElement.scrollIntoView).toHaveBeenCalled();

--- a/src/main/default/lwc/lookup/__tests__/lookupEventHandling.test.js
+++ b/src/main/default/lwc/lookup/__tests__/lookupEventHandling.test.js
@@ -79,6 +79,7 @@ describe('c-lookup event handling', () => {
     });
 
     it('can select item with keyboard', async () => {
+        Element.prototype.scrollIntoView = jest.fn();
         jest.useFakeTimers();
 
         // Create lookup with search handler
@@ -99,6 +100,9 @@ describe('c-lookup event handling', () => {
         // Check selection
         expect(lookupEl.selection.length).toBe(1);
         expect(lookupEl.selection[0].id).toBe(SAMPLE_SEARCH_ITEMS[0].id);
+
+        const focusedElement = lookupEl.shadowRoot.querySelector(`[data-recordid="${SAMPLE_SEARCH_ITEMS[0].id}"]`);
+        expect(focusedElement.scrollIntoView).toHaveBeenCalled();
     });
 
     it('can create new record without pre-navigate callback', async () => {

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -260,9 +260,11 @@ export default class Lookup extends NavigationMixin(LightningElement) {
         }
 
         if (event.keyCode === KEY_ARROW_DOWN || event.keyCode === KEY_ARROW_UP) {
-            const focusedElement = this.template.querySelector(`[data-recordid="${this._searchResults[this._focusedResultIndex].id}"]`);
+            const focusedElement = this.template.querySelector(
+                `[data-recordid="${this._searchResults[this._focusedResultIndex].id}"]`
+            );
             if (focusedElement) {
-                focusedElement.scrollIntoView({ block: 'nearest', inline:'nearest' })
+                focusedElement.scrollIntoView({ block: 'nearest', inline: 'nearest' });
             }
         }
     }

--- a/src/main/default/lwc/lookup/lookup.js
+++ b/src/main/default/lwc/lookup/lookup.js
@@ -258,6 +258,13 @@ export default class Lookup extends NavigationMixin(LightningElement) {
             this.template.querySelector(`[data-recordid="${selectedId}"]`).click();
             event.preventDefault();
         }
+
+        if (event.keyCode === KEY_ARROW_DOWN || event.keyCode === KEY_ARROW_UP) {
+            const focusedElement = this.template.querySelector(`[data-recordid="${this._searchResults[this._focusedResultIndex].id}"]`);
+            if (focusedElement) {
+                focusedElement.scrollIntoView({ block: 'nearest', inline:'nearest' })
+            }
+        }
     }
 
     handleResultClick(event) {


### PR DESCRIPTION
Hi all,

I found an issue related to the list with more than 5 items and scroll-after-n-items="5". Currently if I try to navigate with arrow keys UP and DOWN, the selected element changes but it does not scroll the listbox.

I have implemented a fix for the issue and attached a short video demoing it.

Thanks!

Best,
Jun Yi

**BEFORE FIX:**

https://github.com/user-attachments/assets/4e39ffb4-b638-45c8-a72b-638f1bf7c623

**AFTER FIX:**

https://github.com/user-attachments/assets/91f137de-4588-4cd4-ad95-70189b02f258